### PR TITLE
fix(KMSample2-11-13): Revert onKeyboardLoaded

### DIFF
--- a/KMSample2-11-13/app/build.gradle
+++ b/KMSample2-11-13/app/build.gradle
@@ -29,10 +29,12 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.2.0-alpha02'
     implementation 'com.google.android.material:material:1.0.0'
-    api (name:'keyman-engine11', ext:'aar')
-    implementation "com.google.firebase:firebase-core:17.2.1"
+    api (name:'keyman-engine13', ext:'aar')
+    implementation "com.google.firebase:firebase-core:18.0.0"
     implementation "com.google.firebase:firebase-crash:16.2.1"
+    /*
     implementation('com.crashlytics.sdk.android:crashlytics:2.10.1@aar') {
         transitive = true
     }
+    */
 }

--- a/KMSample2-11-13/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
+++ b/KMSample2-11-13/app/src/main/java/com/keyman/kmsample2/SystemKeyboard.java
@@ -176,8 +176,8 @@ public class SystemKeyboard extends InputMethodService implements OnKeyboardEven
   public void onKeyboardLoaded(KeyboardType keyboardType) {
     // Handle Keyman keyboard loaded event here if needed
     // We can set our custom keyboard here
-    int kbIndex = KMManager.getKeyboardIndex(this, "sil_cameroon_azerty", "ewo");
-    KMManager.setKeyboard(this, kbIndex);
+    //int kbIndex = KMManager.getKeyboardIndex(this, "sil_cameroon_azerty", "ewo");
+    //KMManager.setKeyboard(this, kbIndex);
   }
 
   @Override


### PR DESCRIPTION
I set the project to use KMEA 13, and kept `KMManager.setShouldCheckKeyboardUpdates(false);`

I was puzzled by the original code block
```
public void onKeyboardLoaded(KeyboardType keyboardType) {	  public void onKeyboardLoaded(KeyboardType keyboardType) {
    // Handle Keyman keyboard loaded event here if needed	    // Handle Keyman keyboard loaded event here if needed
    // We can set our custom keyboard here	    // We can set our custom keyboard here
    int kbIndex = KMManager.getKeyboardIndex(this, "sil_cameroon_azerty", "ewo");	    //int kbIndex = KMManager.getKeyboardIndex(this, "sil_cameroon_azerty", "ewo");
    KMManager.setKeyboard(this, kbIndex);	    //KMManager.setKeyboard(this, kbIndex);
  }
```

The `KMManager.setKeyboard()` call will always override the keyboard selection to whatever you have `kbIndex`.
So in your test cases that set the index to "sil_cameroon_qwerty", that would always set the keyboard to "sil_cameroon_qwerty".

When those lines commented out, the System keyboard defaults to sil_cameroon_qwerty. Selecting the globe button to sil_cameroon_azerty then switches the keyboard to sil_cameroon_azerty.
